### PR TITLE
Point URLs to warewulf-web

### DIFF
--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -5,7 +5,7 @@ title: Documentation
 
 We (like almost all open source software providers) have a documentation dilemma… We tend to focus on the code features and functionality before working on documentation. And there is very good reason for this: we want to share the love so nobody feels left out!
 
-You can contribute to the documentation by [raising an issue to suggest an improvement](https://github.com/hpcng/warewulf/issues/new) or by sending a [pull request](https://github.com/hpcng/warewulf/compare) on [our repository](https://github.com/hpcng/warewulf).
+You can contribute to the documentation by [raising an issue to suggest an improvement](https://github.com/hpcng/warewulf-web/issues/new) or by sending a [pull request](https://github.com/hpcng/warewulf-web/compare) on [our repository](https://github.com/hpcng/warewulf-web).
 
 The current documentation is generated with [Docusaurus](https://v2.docusaurus.io/docs/).
 


### PR DESCRIPTION
Update links to point to the warewulf-web docs repo rather than the warewulf repo. 